### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,9 @@ GPIO 44 is default IR output pin.
 >cp Kconfig $SOURCE_PATH/driver/staging/media/lirc/  
 
 **Add the following to .config or enable in menuconfig:**
+>CONFIG_MEDIA_RC_SUPPORT=y
+>CONFIG_MEDIA_SUPPORT=y
+>CONFIG_RC_DECODERS=y
 >CONFIG_RC_CORE=m  
 >CONFIG_LIRC=m  
 >CONFIG_RC_MAP=m  


### PR DESCRIPTION
Last kernels (I tested kernels linux-4.9.40 and linux-4.9.38) also need _CONFIG_MEDIA_RC_SUPPORT=y_, _CONFIG_MEDIA_SUPPORT=y_ and _CONFIG_RC_DECODERS=y_ in _.config_ file to have lirc_sam enabled and compiled.